### PR TITLE
Merge enhancements into master branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 coverage.txt
 dist
+.vscode
+gitprompt

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+.PHONY: all
+all: test build
+
+.PHONY: build
+build:
+	go build cmd/gitprompt/gitprompt.go
+
+.PHONY: test
+test:
+	go test
+
+.PHONY: clean
+clean:
+	rm -f gitprompt
+

--- a/README.md
+++ b/README.md
@@ -69,15 +69,22 @@ with `%`:
 | `%u`  | Number of untracked files                                  |
 | `%S`  | Number of stashed changes                                  |
 | `%U`  | Name of tracked upstream branch                            |
-| `%C`  | Enables group when clean (no output)                       |
-| `%D`  | Enables group when not clean = dirty (no output)           |
-| `%O`  | Enables group when outdated (no output)                    |
-| `%L`  | Enables group when latest or up to date (no output)        |
-| `%l`  | Enables group when local repository (no output)            |
-| `%e`  | Enables group when last group was not enabled (no output)  |
 
 Normally `%h` and `%H` display the current branch (`master`) but if you're detached
 from `HEAD`, the first 7 characters of the current sha1 will be displayed.
+
+### Enablers
+
+The following tokens force-enable or disable a group:
+
+| token | explanation                                                |
+| ----- | ---------------------------------------------------------- |
+| `%C`  | Enable group when clean                                    |
+| `%D`  | Enable group when not clean (or dirty)                     |
+| `%O`  | Enable group when outdated                                 |
+| `%L`  | Enable group when latest (or up to date)                   |
+| `%l`  | Enable group when there's no upstream (local repository)   |
+| `%e`  | Enable group when last group was not enabled               |
 
 ### Colors
 
@@ -126,7 +133,8 @@ escape code is automatically added to clear it.
 ### Groups
 
 Groups can be used for adding logic to the format. A group's output is only
-printed if at least one item in the group has data.
+printed if at least one item in the group has data. There's one exception:
+If the group contains an enabler it is only printed if the enabler is true.
 
 | token | action      |
 | ----- | ----------- |

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ The color can be set with color tokens, prefixed with `#`:
 | `#C`  | Highlight Cyan    |
 | `#W`  | Highlight White   |
 | `#_`  | Reset color       |
+| `#>`  | Leak color        |
 
 The color is set until another color overrides it, or a group ends (see below).
 If a color was set when gitprompt is done, it will add a color reset escape
@@ -126,6 +127,8 @@ The text attributes can be set with attribute tokens, prefixed with `@`:
 | `@F`  | Clear faint/dim color |
 | `@i`  | Set italic            |
 | `@I`  | Clear italic          |
+| `@_`  | Reset attributes      |
+| `@>`  | Leak attributes       |
 
 As with colors, if an attribute was set when gitprompt is done, an additional
 escape code is automatically added to clear it.
@@ -160,10 +163,18 @@ without any formatting, and `ahead` in green:
 [#r behind: %b] - [#g ahead: %a]
 ```
 
-A group requires one data token to have a non-zero value. The following prints
-the current branch/sha1 in cyan, then number of staged files (if not zero),
-then commits behind and ahead (if both are not zero). This allows for symmetry,
-if it's desired to show `master >1 ↓0 ↑2` instead of `master >1 ↑2`:
+You can leak color or attributes intentionally be including a leak token. This
+prints the current branch in green if it's up to date and in red if not:
+
+```
+[[%L#g#>][%e#r#>]%h]
+```
+ 
+To be printed a group requires one data token to have a non-zero value or an
+enabled enabler. The following prints the current branch/sha1 in cyan, then
+number of staged files (if not zero), then commits behind and ahead (if both
+are not zero). This allows for symmetry, if it's desired to show
+`master >1 ↓0 ↑2` instead of `master >1 ↑2`:
 
 ```
 #c%h[ >%s][ ↓%b ↑%a]

--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ with `%`:
 | `%S`  | Number of stashed changes                                  |
 | `%U`  | Name of tracked upstream branch                            |
 | `%C`  | Enables group when clean (no output)                       |
+| `%D`  | Enables group when not clean = dirty (no output)           |
+| `%O`  | Enables group when outdated (no output)                    |
+| `%L`  | Enables group when latest or up to date (no output)        |
 | `%l`  | Enables group when local repository (no output)            |
 | `%e`  | Enables group when last group was not enabled (no output)  |
 

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ Displays:
 - Untracked files
 - Modified files
 - Staged files
+- Conflicts
 - Commits behind / ahead remote
 
-When executed, gitprompt gets the git status of the current working directory
-then prints it according to the format specified. If the current working
-directory is not part of a git repository, gitprompt
-exits with code `0` and no output.
+When executed, gitprompt gets the git status of the current working directory then
+prints it according to the format specified. If the current working directory is
+not part of a git repository, gitprompt exits with code `0` and no output.
 
 `*` git is required
 
@@ -57,19 +57,24 @@ characters are fine, go crazy with emojis if that's your thing)_.
 Various data from git can be displayed in the output. Data tokens are prefixed
 with `%`:
 
-| token | explanation                       |
-| ----- | --------------------------------- |
-| `%h`  | Current branch or sha1            |
-| `%s`  | Number of files staged            |
-| `%b`  | Number of commits behind remote   |
-| `%a`  | Number of commits ahead of remote |
-| `%c`  | Number of conflicts               |
-| `%m`  | Number of files modified          |
-| `%u`  | Number of untracked files         |
+| token | explanation                                                |
+| ----- | ---------------------------------------------------------- |
+| `%h`  | Current branch or sha1                                     |
+| `%H`  | Current branch or first 7 hex-digits of SHA1 prefixed by : |
+| `%s`  | Number of files staged                                     |
+| `%b`  | Number of commits behind remote                            |
+| `%a`  | Number of commits ahead of remote                          |
+| `%c`  | Number of conflicts                                        |
+| `%m`  | Number of files modified                                   |
+| `%u`  | Number of untracked files                                  |
+| `%S`  | Number of stashed changes                                  |
+| `%U`  | Name of tracked upstream branch                            |
+| `%C`  | Enables group when clean (no output)                       |
+| `%l`  | Enables group when local repository (no output)            |
+| `%e`  | Enables group when last group was not enabled (no output)  |
 
-Normally `%h` displays the current branch (`master`) but if you're detached
-from `HEAD`, it will display the current sha1. Only first 7 characters of the
-sha1 are displayed.
+Normally `%h` and `%H` display the current branch (`master`) but if you're detached
+from `HEAD`, the first 7 characters of the current sha1 will be displayed.
 
 ### Colors
 
@@ -93,6 +98,7 @@ The color can be set with color tokens, prefixed with `#`:
 | `#M`  | Highlight Magenta |
 | `#C`  | Highlight Cyan    |
 | `#W`  | Highlight White   |
+| `#_`  | Reset color       |
 
 The color is set until another color overrides it, or a group ends (see below).
 If a color was set when gitprompt is done, it will add a color reset escape
@@ -169,7 +175,7 @@ gitprompt -format="#B(@b#R%h[#y >%s][#m ↓%b ↑%a][#r x%c][#g +%m][#y ϟ%u]#B)
 - If files are untracked (added since last commit), show a lightning and the number in yellow
 - `)` in highlight blue
 
-> Any text printed after gitprompt will have all formatting cleared
+> Any text printed after gitprompt will have all formatting cleared.
 
 ## Installation
 
@@ -253,7 +259,7 @@ export PS1='$PS1 $(gitprompt)'
 See [bashrcgenerator] for more, just add `$(gitprompt)` where you want the git
 status to appear.
 
-### Uninstallation
+### Uninstall
 
 1. Remove `gitprompt` from your shell config
 2. Delete the binary `rm $(which gitprompt)` or `brew uninstall gitprompt`

--- a/cmd/gitprompt/gitprompt.go
+++ b/cmd/gitprompt/gitprompt.go
@@ -79,6 +79,9 @@ func showHelp() {
     %%S  Number of stashed changes
     %%U  Name of tracked upstream branch
     %%C  Enables group when clean (no output)
+    %%D  Enables group when not clean = dirty (no output)
+    %%O  Enables group when outdated (no output)
+    %%L  Enables group when latest or up to date (no output)
     %%l  Enables group when local repository (no output)
     %%e  Enables group when last group was not enabled (no output)
 

--- a/cmd/gitprompt/gitprompt.go
+++ b/cmd/gitprompt/gitprompt.go
@@ -105,6 +105,7 @@ func showHelp() {
     #C  Highlight Cyan
     #W  Highlight White
     #_  Reset color
+    #>  Leak color
 
   Text attributes:
     @b  Set bold
@@ -113,6 +114,8 @@ func showHelp() {
     @F  Clear faint/dim color
     @i  Set italic
     @I  Clear italic
+    @_  Reset attributes
+    @>  Leak attributes
 
 `, defaultFormat, example)
 }

--- a/cmd/gitprompt/gitprompt.go
+++ b/cmd/gitprompt/gitprompt.go
@@ -78,12 +78,14 @@ func showHelp() {
     %%u  Number of untracked files
     %%S  Number of stashed changes
     %%U  Name of tracked upstream branch
-    %%C  Enables group when clean (no output)
-    %%D  Enables group when not clean = dirty (no output)
-    %%O  Enables group when outdated (no output)
-    %%L  Enables group when latest or up to date (no output)
-    %%l  Enables group when local repository (no output)
-    %%e  Enables group when last group was not enabled (no output)
+
+  Enablers force-enable a group:
+    %%C  Enable group when clean
+    %%D  Enable group when not clean (or dirty)
+    %%O  Enable group when outdated
+    %%L  Enable group when latest (or up to date)
+    %%l  Enable group when there's no upstream (local repository)
+    %%e  Enable group when last group was not enabled
 
   Colors:
     #k  Black

--- a/cmd/gitprompt/gitprompt.go
+++ b/cmd/gitprompt/gitprompt.go
@@ -40,87 +40,106 @@ func (f *formatFlag) String() string {
 	return defaultFormat
 }
 
-var format formatFlag
+func showHelp() {
 
-var exampleStatus = &gitprompt.GitStatus{
-	Branch:    "master",
-	Sha:       "0455b83f923a40f0b485665c44aa068bc25029f5",
-	Untracked: 1,
-	Modified:  2,
-	Staged:    3,
-	Conflicts: 4,
-	Ahead:     5,
-	Behind:    6,
-}
+	var exampleStatus = &gitprompt.GitStatus{
+		Branch:    "master",
+		Sha:       "0455b83f923a40f0b485665c44aa068bc25029f5",
+		Untracked: 1,
+		Modified:  2,
+		Staged:    3,
+		Conflicts: 4,
+		Ahead:     5,
+		Behind:    6,
+		Stashed:   7,
+		Upstream:  "origin/master",
+		Clean:     true,
+	}
 
-var formatHelp = func() string {
-	example, _ := gitprompt.Print(exampleStatus, defaultFormat)
-	return fmt.Sprintf(`Define output format.
+	out := flag.CommandLine.Output()
 
-Default format is: %q
-Example result:    %s
+	fmt.Fprintf(out, "Usage:\n\n")
+	flag.CommandLine.PrintDefaults()
 
-Data:
-	%%h	Current branch or SHA1
-	%%s	Number of files staged
-	%%b	Number of commits behind remote
-	%%a	Number of commits ahead of remote
-	%%c	Number of conflicts
-	%%m	Number of files modified
-	%%u	Number of untracked files
+	example := gitprompt.Print(exampleStatus, defaultFormat, false)
 
-Colors:
-	#k	Black
-	#r	Red
-	#g	Green
-	#y	Yellow
-	#b	Blue
-	#m	Magenta
-	#c	Cyan
-	#w	White
-	#K	Highlight Black
-	#R	Highlight Red
-	#G	Highlight Green
-	#Y	Highlight Yellow
-	#B	Highlight Blue
-	#M	Highlight Magenta
-	#C	Highlight Cyan
-	#W	Highlight White
+	fmt.Fprintf(out, `
+  Default format: %q
+  Example result: %s
 
-Text attributes:
-	@b	Set bold
-	@B	Clear bold
-	@f	Set faint/dim color
-	@F	Clear faint/dim color
-	@i	Set italic
-	@I	Clear italic`, defaultFormat, example)
+  Data:
+    %%h  Current branch or first 7 hex-digits of SHA1
+    %%H  Current branch or first 7 hex-digits of SHA1 prefixed by :
+    %%s  Number of files staged
+    %%b  Number of commits behind remote
+    %%a  Number of commits ahead of remote
+    %%c  Number of conflicts
+    %%m  Number of files modified
+    %%u  Number of untracked files
+    %%S  Number of stashed changes
+    %%U  Name of tracked upstream branch
+    %%C  Enables group when clean (no output)
+    %%l  Enables group when local repository (no output)
+    %%e  Enables group when last group was not enabled (no output)
+
+  Colors:
+    #k  Black
+    #r  Red
+    #g  Green
+    #y  Yellow
+    #b  Blue
+    #m  Magenta
+    #c  Cyan
+    #w  White
+    #K  Highlight Black
+    #R  Highlight Red
+    #G  Highlight Green
+    #Y  Highlight Yellow
+    #B  Highlight Blue
+    #M  Highlight Magenta
+    #C  Highlight Cyan
+    #W  Highlight White
+    #_  Reset color
+
+  Text attributes:
+    @b  Set bold
+    @B  Clear bold
+    @f  Set faint/dim color
+    @F  Clear faint/dim color
+    @i  Set italic
+    @I  Clear italic
+
+`, defaultFormat, example)
 }
 
 func main() {
-	v := flag.Bool("version", false, "Print version inforformation.")
+
+	var format formatFlag
+
+	v := flag.Bool("version", false, "Print version information")
 	zsh := flag.Bool("zsh", false, "Print zsh width control characters")
-	flag.Var(&format, "format", formatHelp())
+	flag.Usage = showHelp
+	flag.Var(&format, "format", "Define output format (see below)")
 	flag.Parse()
 
 	if *v {
-		fmt.Printf("Version:    %s\n", version)
-		fmt.Printf("Commit:     %s\n", commit)
-		fmt.Printf("Build date: %s\n", date)
-		fmt.Printf("Go version: %s\n", goversion)
+		fmt.Printf(
+			"Version:    %s\nCommit:     %s\nBuild date: %s\nGo version: %s\n",
+			version, commit, date, goversion)
 		os.Exit(0)
 	}
 
 	s, err := gitprompt.Parse()
 	if err != nil {
-		_, _ = fmt.Fprintln(os.Stderr, err)
+		if !*zsh {
+			fmt.Fprintln(os.Stderr, err)
+		}
 		os.Exit(1)
 	}
 	if s == nil {
 		return
 	}
-	out, num := gitprompt.Print(s, format.String())
-	_, _ = fmt.Fprint(os.Stdout, out)
-	if *zsh {
-		_, _ = fmt.Fprintf(os.Stdout, "%%%dG", num)
-	}
+
+	fmt.Print(gitprompt.Print(s, format.String(), *zsh))
+
 }

--- a/parser.go
+++ b/parser.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"errors"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -106,6 +107,8 @@ func runGitCommand(cmd string, args ...string) (string, error) {
 	command := exec.Command(cmd, args...)
 	command.Stdout = bufio.NewWriter(&stdout)
 	command.Stderr = bufio.NewWriter(&stderr)
+	command.Env = os.Environ()
+	command.Env = append(command.Env, "LC_ALL=C")
 
 	if err := command.Run(); err != nil {
 		if stderr.Len() > 0 {

--- a/parser.go
+++ b/parser.go
@@ -23,6 +23,7 @@ type GitStatus struct {
 	Stashed   int
 	Upstream  string
 	Clean     bool
+	Outdated  bool
 }
 
 // Parse parses the status for the repository from git. Returns nil if the
@@ -58,10 +59,13 @@ func Parse() (*GitStatus, error) {
 		}
 	}
 
-	status.Clean = !(status.Untracked != 0 ||
-		status.Modified != 0 ||
-		status.Staged != 0 ||
-		status.Conflicts != 0)
+	status.Clean = status.Conflicts == 0 &&
+		status.Staged == 0 &&
+		status.Modified == 0
+	status.Outdated = !status.Clean ||
+		status.Ahead != 0 ||
+		status.Behind != 0 ||
+		status.Untracked != 0
 
 	if stashed, err := runGitCommand("git", "rev-list", "--walk-reflogs", "--count", "refs/stash"); err == nil {
 		if s, err := strconv.Atoi(stashed); err == nil {

--- a/parser_test.go
+++ b/parser_test.go
@@ -24,7 +24,7 @@ func TestParseValues(t *testing.T) {
 		{
 			name: "dirty",
 			setup: `
-				git init -b main
+				git init --initial-branch=master || git init
 				touch test
 			`,
 			expected: &GitStatus{
@@ -34,7 +34,7 @@ func TestParseValues(t *testing.T) {
 		{
 			name: "staged",
 			setup: `
-				git init -b main
+				git init --initial-branch=master || git init
 				touch test
 				git add test
 			`,
@@ -45,7 +45,7 @@ func TestParseValues(t *testing.T) {
 		{
 			name: "modified",
 			setup: `
-				git init -b main
+				git init --initial-branch=master || git init
 				echo "hello" >> test
 				git add test
 				git commit -m 'initial'
@@ -58,7 +58,7 @@ func TestParseValues(t *testing.T) {
 		{
 			name: "deleted",
 			setup: `
-				git init -b main
+				git init --initial-branch=master || git init
 				echo "hello" >> test
 				git add test
 				git commit -m 'initial'
@@ -71,10 +71,10 @@ func TestParseValues(t *testing.T) {
 		{
 			name: "conflicts",
 			setup: `
-				git init -b main
+				git init --initial-branch=master || git init
 				git commit --allow-empty -m 'initial'
 				git checkout -b other
-				git checkout main
+				git checkout master
 				echo foo >> test
 				git add test
 				git commit -m 'first'
@@ -82,7 +82,7 @@ func TestParseValues(t *testing.T) {
 				echo bar >> test
 				git add test
 				git commit -m 'first'
-				git rebase main || true
+				git rebase master || true
 			`,
 			expected: &GitStatus{
 				Conflicts: 1,
@@ -91,7 +91,7 @@ func TestParseValues(t *testing.T) {
 		{
 			name: "ahead",
 			setup: `
-				git init -b main
+				git init --initial-branch=master || git init
 				git remote add origin $REMOTE
 				git commit --allow-empty -m 'first'
 				git push -u origin HEAD
@@ -99,14 +99,14 @@ func TestParseValues(t *testing.T) {
 			`,
 			expected: &GitStatus{
 				Ahead:    1,
-				Upstream: "origin/main",
+				Upstream: "origin/master",
 				Clean:    true,
 			},
 		},
 		{
 			name: "behind",
 			setup: `
-				git init -b main
+				git init --initial-branch=master || git init
 				git remote add origin $REMOTE
 				git commit --allow-empty -m 'first'
 				git commit --allow-empty -m 'second'
@@ -115,14 +115,14 @@ func TestParseValues(t *testing.T) {
 			`,
 			expected: &GitStatus{
 				Behind:   1,
-				Upstream: "origin/main",
+				Upstream: "origin/master",
 				Clean:    true,
 			},
 		},
 		{
 			name: "stashed",
 			setup: `
-				git init -b main
+				git init --initial-branch=master || git init
 				echo "hello" >> test
 				git add test
 				git commit -m 'initial'
@@ -177,16 +177,16 @@ func TestParseHead(t *testing.T) {
 	defer done()
 
 	setupCommands(t, dir, `
-		git init -b main
+		git init --initial-branch=master || git init
 	`)
 	s, _ := Parse()
-	assertString(t, "branch", "main", s.Branch)
+	assertString(t, "branch", "master", s.Branch)
 
 	setupCommands(t, dir, `
 		git commit --allow-empty -m 'initial'
 	`)
 	s, _ = Parse()
-	assertString(t, "branch", "main", s.Branch)
+	assertString(t, "branch", "master", s.Branch)
 
 	setupCommands(t, dir, `
 		git checkout -b other

--- a/parser_test.go
+++ b/parser_test.go
@@ -98,7 +98,9 @@ func TestParseValues(t *testing.T) {
 				git commit --allow-empty -m 'second'
 			`,
 			expected: &GitStatus{
-				Ahead: 1,
+				Ahead:    1,
+				Upstream: "origin/master",
+				Clean:    true,
 			},
 		},
 		{
@@ -112,7 +114,24 @@ func TestParseValues(t *testing.T) {
 				git reset --hard HEAD^
 			`,
 			expected: &GitStatus{
-				Behind: 1,
+				Behind:   1,
+				Upstream: "origin/master",
+				Clean:    true,
+			},
+		},
+		{
+			name: "stashed",
+			setup: `
+				git init
+				echo "hello" >> test
+				git add test
+				git commit -m 'initial'
+				echo "world" >> test
+				git stash
+			`,
+			expected: &GitStatus{
+				Stashed: 1,
+				Clean:   true,
 			},
 		},
 	}
@@ -146,6 +165,9 @@ func TestParseValues(t *testing.T) {
 			assertInt(t, "Conflicts", test.expected.Conflicts, actual.Conflicts)
 			assertInt(t, "Ahead", test.expected.Ahead, actual.Ahead)
 			assertInt(t, "Behind", test.expected.Behind, actual.Behind)
+			assertInt(t, "Stashed", test.expected.Stashed, actual.Stashed)
+			assertString(t, "Upstream", test.expected.Upstream, actual.Upstream)
+			assertBool(t, "Clean", test.expected.Clean, actual.Clean)
 		})
 	}
 }
@@ -261,6 +283,14 @@ func assertString(t *testing.T, name, expected, actual string) {
 }
 
 func assertInt(t *testing.T, name string, expected, actual int) {
+	t.Helper()
+	if expected == actual {
+		return
+	}
+	t.Errorf("%s does not match\n\tExpected: %v\n\tActual:   %v", name, expected, actual)
+}
+
+func assertBool(t *testing.T, name string, expected, actual bool) {
 	t.Helper()
 	if expected == actual {
 		return

--- a/parser_test.go
+++ b/parser_test.go
@@ -24,7 +24,7 @@ func TestParseValues(t *testing.T) {
 		{
 			name: "dirty",
 			setup: `
-				git init
+				git init -b main
 				touch test
 			`,
 			expected: &GitStatus{
@@ -34,7 +34,7 @@ func TestParseValues(t *testing.T) {
 		{
 			name: "staged",
 			setup: `
-				git init
+				git init -b main
 				touch test
 				git add test
 			`,
@@ -45,7 +45,7 @@ func TestParseValues(t *testing.T) {
 		{
 			name: "modified",
 			setup: `
-				git init
+				git init -b main
 				echo "hello" >> test
 				git add test
 				git commit -m 'initial'
@@ -58,7 +58,7 @@ func TestParseValues(t *testing.T) {
 		{
 			name: "deleted",
 			setup: `
-				git init
+				git init -b main
 				echo "hello" >> test
 				git add test
 				git commit -m 'initial'
@@ -71,10 +71,10 @@ func TestParseValues(t *testing.T) {
 		{
 			name: "conflicts",
 			setup: `
-				git init
+				git init -b main
 				git commit --allow-empty -m 'initial'
 				git checkout -b other
-				git checkout master
+				git checkout main
 				echo foo >> test
 				git add test
 				git commit -m 'first'
@@ -82,7 +82,7 @@ func TestParseValues(t *testing.T) {
 				echo bar >> test
 				git add test
 				git commit -m 'first'
-				git rebase master || true
+				git rebase main || true
 			`,
 			expected: &GitStatus{
 				Conflicts: 1,
@@ -91,7 +91,7 @@ func TestParseValues(t *testing.T) {
 		{
 			name: "ahead",
 			setup: `
-				git init
+				git init -b main
 				git remote add origin $REMOTE
 				git commit --allow-empty -m 'first'
 				git push -u origin HEAD
@@ -99,14 +99,14 @@ func TestParseValues(t *testing.T) {
 			`,
 			expected: &GitStatus{
 				Ahead:    1,
-				Upstream: "origin/master",
+				Upstream: "origin/main",
 				Clean:    true,
 			},
 		},
 		{
 			name: "behind",
 			setup: `
-				git init
+				git init -b main
 				git remote add origin $REMOTE
 				git commit --allow-empty -m 'first'
 				git commit --allow-empty -m 'second'
@@ -115,14 +115,14 @@ func TestParseValues(t *testing.T) {
 			`,
 			expected: &GitStatus{
 				Behind:   1,
-				Upstream: "origin/master",
+				Upstream: "origin/main",
 				Clean:    true,
 			},
 		},
 		{
 			name: "stashed",
 			setup: `
-				git init
+				git init -b main
 				echo "hello" >> test
 				git add test
 				git commit -m 'initial'
@@ -177,16 +177,16 @@ func TestParseHead(t *testing.T) {
 	defer done()
 
 	setupCommands(t, dir, `
-		git init
+		git init -b main
 	`)
 	s, _ := Parse()
-	assertString(t, "branch", "master", s.Branch)
+	assertString(t, "branch", "main", s.Branch)
 
 	setupCommands(t, dir, `
 		git commit --allow-empty -m 'initial'
 	`)
 	s, _ = Parse()
-	assertString(t, "branch", "master", s.Branch)
+	assertString(t, "branch", "main", s.Branch)
 
 	setupCommands(t, dir, `
 		git checkout -b other

--- a/parser_test.go
+++ b/parser_test.go
@@ -29,6 +29,8 @@ func TestParseValues(t *testing.T) {
 			`,
 			expected: &GitStatus{
 				Untracked: 1,
+				Clean:     true,
+				Outdated:  true,
 			},
 		},
 		{
@@ -39,7 +41,9 @@ func TestParseValues(t *testing.T) {
 				git add test
 			`,
 			expected: &GitStatus{
-				Staged: 1,
+				Staged:   1,
+				Clean:    false,
+				Outdated: true,
 			},
 		},
 		{
@@ -53,6 +57,8 @@ func TestParseValues(t *testing.T) {
 			`,
 			expected: &GitStatus{
 				Modified: 1,
+				Clean:    false,
+				Outdated: true,
 			},
 		},
 		{
@@ -66,6 +72,8 @@ func TestParseValues(t *testing.T) {
 			`,
 			expected: &GitStatus{
 				Modified: 1,
+				Clean:    false,
+				Outdated: true,
 			},
 		},
 		{
@@ -86,6 +94,8 @@ func TestParseValues(t *testing.T) {
 			`,
 			expected: &GitStatus{
 				Conflicts: 1,
+				Clean:     false,
+				Outdated:  true,
 			},
 		},
 		{
@@ -101,6 +111,7 @@ func TestParseValues(t *testing.T) {
 				Ahead:    1,
 				Upstream: "origin/master",
 				Clean:    true,
+				Outdated: true,
 			},
 		},
 		{
@@ -117,6 +128,7 @@ func TestParseValues(t *testing.T) {
 				Behind:   1,
 				Upstream: "origin/master",
 				Clean:    true,
+				Outdated: true,
 			},
 		},
 		{
@@ -130,8 +142,9 @@ func TestParseValues(t *testing.T) {
 				git stash
 			`,
 			expected: &GitStatus{
-				Stashed: 1,
-				Clean:   true,
+				Stashed:  1,
+				Clean:    true,
+				Outdated: false,
 			},
 		},
 	}
@@ -168,6 +181,7 @@ func TestParseValues(t *testing.T) {
 			assertInt(t, "Stashed", test.expected.Stashed, actual.Stashed)
 			assertString(t, "Upstream", test.expected.Upstream, actual.Upstream)
 			assertBool(t, "Clean", test.expected.Clean, actual.Clean)
+			assertBool(t, "Outdated", test.expected.Outdated, actual.Outdated)
 		})
 	}
 }

--- a/printer.go
+++ b/printer.go
@@ -64,6 +64,9 @@ const (
 	stashed   rune = 'S'
 	upstream  rune = 'U'
 	clean     rune = 'C'
+	dirty     rune = 'D'
+	outdated  rune = 'O'
+	latest    rune = 'L'
 	local     rune = 'l'
 	if_else   rune = 'e'
 )
@@ -310,9 +313,24 @@ func setData(g *group, s *GitStatus, last bool, ch rune) {
 		if s.Clean {
 			g.hasValue = true
 		}
+	case dirty:
+		g.hasData = true
+		if !s.Clean {
+			g.hasValue = true
+		}
+	case outdated:
+		g.hasData = true
+		if s.Outdated {
+			g.hasValue = true
+		}
+	case latest:
+		g.hasData = true
+		if !s.Outdated {
+			g.hasValue = true
+		}
 	case local:
 		g.hasData = true
-		if s.Upstream == "" && s.Branch != "" {
+		if s.Upstream == "" {
 			g.hasValue = true
 		}
 	case if_else:

--- a/printer_test.go
+++ b/printer_test.go
@@ -1,6 +1,9 @@
 package gitprompt
 
 import (
+	"fmt"
+	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -13,39 +16,43 @@ var all = &GitStatus{
 	Conflicts: 3,
 	Ahead:     4,
 	Behind:    5,
+	Stashed:   6,
+	Upstream:  "origin/master",
+	Clean:     true,
 }
 
-func TestPrinterEmpty(t *testing.T) {
-	actual, w := Print(nil, "%h")
-	assertOutput(t, "", actual)
-	assertWidth(t, 0, w)
-}
-
-func TestPrinterData(t *testing.T) {
-	actual, w := Print(all, "%h %u %m %s %c %a %b")
-	assertOutput(t, "master 0 1 2 3 4 5", actual)
-	assertWidth(t, 18, w)
-}
-
-func TestPrinterUnicode(t *testing.T) {
-	actual, w := Print(all, "%h ✋%u ⚡️%m 🚚%s ❗️%c ⬆%a ⬇%b")
-	assertOutput(t, "master ✋0 ⚡️1 🚚2 ❗️3 ⬆4 ⬇5", actual)
-	assertWidth(t, 26, w)
-}
-
-func TestShortSHA(t *testing.T) {
-	actual, w := Print(&GitStatus{Sha: "858828b5e153f24644bc867598298b50f8223f9b"}, "%h")
-	assertOutput(t, "858828b", actual)
-	assertWidth(t, 7, w)
-}
-
-func TestPrinterColorAttributes(t *testing.T) {
+func TestPrint(t *testing.T) {
 	tests := []struct {
 		name     string
+		status   *GitStatus
 		format   string
 		expected string
 		width    int
 	}{
+		// output
+		{
+			name:     "empty",
+			format:   "%e",
+			expected: "",
+		},
+		{
+			name:     "all data",
+			format:   "%h %u %m %s %c %a %b %S %U",
+			expected: "master 0 1 2 3 4 5 6 origin/master",
+		},
+		{
+			name:     "unicode",
+			format:   "%h ✋%u ⚡️%m 🚚%s ❗️%c ⬆%a ⬇%b",
+			expected: "master ✋0 ⚡️1 🚚2 ❗️3 ⬆4 ⬇5",
+			width:    26,
+		},
+		{
+			name:     "sha",
+			status:   &GitStatus{Sha: "858828b5e153f24644bc867598298b50f8223f9b"},
+			format:   "%h%H",
+			expected: "858828b:858828b",
+		},
+		// colors
 		{
 			name:     "red",
 			format:   "#r%h",
@@ -98,43 +105,22 @@ func TestPrinterColorAttributes(t *testing.T) {
 			name:     "ending with #",
 			format:   "%h#",
 			expected: "master#",
-			width:    7,
 		},
 		{
 			name:     "ending with !",
 			format:   "%h!",
 			expected: "master!",
-			width:    7,
 		},
 		{
 			name:     "ending with @",
 			format:   "%h@",
 			expected: "master@",
-			width:    7,
 		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			actual, w := Print(all, test.format)
-			assertOutput(t, test.expected, actual)
-			assertWidth(t, test.width, w)
-		})
-	}
-}
-
-func TestPrinterGroups(t *testing.T) {
-	tests := []struct {
-		name     string
-		format   string
-		expected string
-		width    int
-	}{
+		// groups
 		{
 			name:     "groups",
-			format:   "<[%h][ B%b A%a][ U%u][ C%c]>",
-			expected: "<master B5 A4 C3>",
-			width:    17,
+			format:   "<[%h][ B%b A%a][ U%u][ C%c][ %CX][%ll][%eY]>",
+			expected: "<master B5 A4 C3 XY>",
 		},
 		{
 			name:     "group color",
@@ -142,47 +128,31 @@ func TestPrinterGroups(t *testing.T) {
 			expected: "<\x1b[31mmaster\x1b[0m-4-\x1b[34m5\x1b[0m>",
 			width:    12,
 		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			actual, w := Print(all, test.format)
-			assertOutput(t, test.expected, actual)
-			assertWidth(t, test.width, w)
-		})
-	}
-}
-
-func TestPrinterNonMatching(t *testing.T) {
-	tests := []struct {
-		name     string
-		format   string
-		expected string
-		width    int
-	}{
+		{
+			name:     "group invalid",
+			format:   "]",
+			expected: "]",
+		},
+		// non matching
 		{
 			name:     "data valid odd",
 			format:   "%%%h",
 			expected: "%%master",
-			width:    8,
 		},
 		{
 			name:     "data valid even",
 			format:   "%%%%h",
 			expected: "%%%%h",
-			width:    5,
 		},
 		{
 			name:     "data invalid odd",
 			format:   "%%%z",
 			expected: "%%%z",
-			width:    4,
 		},
 		{
 			name:     "data invalid even",
 			format:   "%%%%z",
 			expected: "%%%%z",
-			width:    5,
 		},
 		{
 			name:     "color valid odd",
@@ -194,19 +164,16 @@ func TestPrinterNonMatching(t *testing.T) {
 			name:     "color valid even",
 			format:   "####rA",
 			expected: "####rA",
-			width:    6,
 		},
 		{
 			name:     "color invalid odd",
 			format:   "###zA",
 			expected: "###zA",
-			width:    5,
 		},
 		{
 			name:     "color invalid even",
 			format:   "####zA",
 			expected: "####zA",
-			width:    6,
 		},
 		{
 			name:     "attribute valid odd",
@@ -218,106 +185,100 @@ func TestPrinterNonMatching(t *testing.T) {
 			name:     "attribute valid even",
 			format:   "@@@@bA",
 			expected: "@@@@bA",
-			width:    6,
 		},
 		{
 			name:     "attribute invalid odd",
 			format:   "@@@zA",
 			expected: "@@@zA",
-			width:    5,
 		},
 		{
 			name:     "attribute invalid even",
 			format:   "@@@@zA",
 			expected: "@@@@zA",
-			width:    6,
 		},
 		{
 			name:     "trailing %",
 			format:   "A%",
 			expected: "A%",
-			width:    2,
 		},
 		{
 			name:     "trailing #",
 			format:   "A#",
 			expected: "A#",
-			width:    2,
 		},
 		{
 			name:     "trailing @",
 			format:   "A@",
 			expected: "A@",
-			width:    2,
 		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			actual, w := Print(all, test.format)
-			assertOutput(t, test.expected, actual)
-			assertWidth(t, test.width, w)
-		})
-	}
-}
-
-func TestPrinterEscape(t *testing.T) {
-	tests := []struct {
-		name     string
-		format   string
-		expected string
-		width    int
-	}{
+		// escapes
 		{
 			name:     "data",
 			format:   "A\\%h",
 			expected: "A%h",
-			width:    3,
 		},
 		{
 			name:     "color",
 			format:   "A\\#rB",
 			expected: "A#rB",
-			width:    4,
 		},
 		{
 			name:     "attribute",
 			format:   "A\\!bB",
 			expected: "A!bB",
-			width:    4,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actual, w := Print(all, test.format)
-			assertOutput(t, test.expected, actual)
-			assertWidth(t, test.width, w)
+
+			if test.status == nil {
+				test.status = all
+			}
+			if test.width == 0 {
+				test.width = len(test.expected)
+			}
+			actual := Print(test.status, test.format, true)
+
+			// check zsh-formatted output: "%{<OUTPUT>%<WIDTH>G%}"
+			expected := fmt.Sprintf("%%{%s%%%dG%%}", test.expected, test.width)
+			if !strings.HasPrefix(actual, "%{") || !strings.HasSuffix(actual, "G%}") {
+				fail(t, "Invalid zsh-formatted output", expected, actual)
+				return
+			}
+			actual = actual[2 : len(actual)-3]
+
+			split := strings.LastIndex(actual, "%")
+			if split < 0 {
+				fail(t, "Invalid zsh-formatted output", expected, actual)
+				return
+			}
+			width, err := strconv.Atoi(actual[split+1:])
+			actual = actual[:split]
+			if err != nil {
+				fail(t, "Invalid zsh-formatted output", expected, actual)
+				return
+			}
+
+			if width != test.width {
+				fail(t, fmt.Sprintf("Width does not match; expected %d, actual %d", test.width, width),
+					test.expected, actual)
+				return
+			}
+
+			if actual != test.expected {
+				fail(t, "Output mismatch", test.expected, actual)
+				return
+			}
+
 		})
 	}
 }
 
-func assertOutput(t *testing.T, expected, actual string) {
+func fail(t *testing.T, message, expected, actual string) {
 	t.Helper()
-	if actual == expected {
-		return
-	}
-	actualEscaped := actual + "\x1b[0m"
-	t.Errorf(`
-Expected:    %s
-            %q
-Actual:      %s
-            %q`,
-		expected,
-		expected,
-		actualEscaped,
-		actual,
+	t.Errorf(
+		"%s\nExpected:  %s\n          %q\nActual:    %s\x1b[0m\n          %q",
+		message, expected, expected, actual, actual,
 	)
-}
-
-func assertWidth(t *testing.T, expected, actual int) {
-	t.Helper()
-	if expected != actual {
-		t.Errorf("Width does not match; expected %d, actual %d", expected, actual)
-	}
 }

--- a/printer_test.go
+++ b/printer_test.go
@@ -123,9 +123,27 @@ func TestPrint(t *testing.T) {
 			expected: "<master B5 A4 C3 XY>",
 		},
 		{
-			name:     "group color",
+			name:     "group color auto-reset",
 			format:   "<[#r%h]-[#g%u]%a[-#b%b]>",
 			expected: "<\x1b[31mmaster\x1b[0m-4-\x1b[34m5\x1b[0m>",
+			width:    12,
+		},
+		{
+			name:     "group color leak",
+			format:   "<[#r%h]-[#g%u]%a[-#b%b#>]>",
+			expected: "<\x1b[31mmaster\x1b[0m-4-\x1b[34m5>\x1b[0m",
+			width:    12,
+		},
+		{
+			name:     "group attribute auto-reset",
+			format:   "<[@b%h]-[@f%u]%a[-@i%b]>",
+			expected: "<\x1b[1mmaster\x1b[0m-4-\x1b[3m5\x1b[0m>",
+			width:    12,
+		},
+		{
+			name:     "group attribute leak",
+			format:   "<[@b%h]-[@f%u]%a[-@i%b@>]>",
+			expected: "<\x1b[1mmaster\x1b[0m-4-\x1b[3m5>\x1b[0m",
 			width:    12,
 		},
 		{


### PR DESCRIPTION
Some enhancements to gitprompt:
- show shortened hash
- show untracked files
- show stashed changes
- add new group enablers (clean, dirty, outdated, up2date, no upstream)
- add group enabler to mimic if-then-else
- add reset color
- allow to leak color to next group (no reset when leaving group)

Some fixes:
- speed up gitprompt, by not rendering help on every call
- fix crash when closing a group which was not opened
- use LC_ALL=C to stabilize gitprompt in other locale environments
- make tests not fail on newer git versions using "main" instead af "master" as default branch 
